### PR TITLE
Fix missing / in extracted file names

### DIFF
--- a/fatbin.go
+++ b/fatbin.go
@@ -273,7 +273,7 @@ func extractFile(dstDir string, fileInfo FileInfo, data []byte) error {
 	if len(dstDir) == 0 || dstDir == "/" {
 		return fmt.Errorf("Error in the dst dir: %s\n", dstDir)
 	}
-	file, err := os.Create(dstDir + fileInfo.Name)
+	file, err := os.Create(dstDir + "/" + fileInfo.Name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
On my system with TMPDIR=/tmp/user/1000 (using libpam-tmpdir), the files
extracted from the archive end up missing a slash, which prevents the
fatbin from running correctly.
